### PR TITLE
XcodebuildConfiguration: Add other-flags param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .phutil_module_cache
 *~
 .*.sw[a-z]
+.DS_Store

--- a/src/configuration/XcodebuildConfiguration.php
+++ b/src/configuration/XcodebuildConfiguration.php
@@ -58,14 +58,18 @@ final class XcodebuildConfiguration {
         $this->configuration = $this->getConfigValue('xcodebuild.configuration', $this->configuration);
         $this->scheme = $this->getConfigValue('xcodebuild.scheme', $this->scheme);
         $this->xcodebuildBin = $this->getXcodebuildPath();
-        $this->otherFlags = $this->getConfigValue('xcodebuild.other-flags');
+        $this->otherFlags = $this->configurationManager->getConfigFromAnySource('xcodebuild.other-flags');
     }
 
     public function buildCommand(array $flags) {
         $this->loadConfig();
 
         if ($this->otherFlags) {
-            array_push($flags, $this->otherFlags);
+            array_push($flags, $this->otherFlags);            
+        } 
+        
+        if (!$this->otherFlags || strpos($this->otherFlags,'-dry-run') === false) {
+            array_unshift($flags, "clean");
         }
         
         $command = new PhutilCommandString(array(

--- a/src/configuration/XcodebuildConfiguration.php
+++ b/src/configuration/XcodebuildConfiguration.php
@@ -68,7 +68,7 @@ final class XcodebuildConfiguration {
             array_push($flags, $this->otherFlags);            
         } 
         
-        if (!$this->otherFlags || strpos($this->otherFlags,'-dry-run') === false) {
+        if (!$this->otherFlags || strpos($this->otherFlags, '-dry-run') === false) {
             array_unshift($flags, "clean");
         }
         

--- a/src/configuration/XcodebuildConfiguration.php
+++ b/src/configuration/XcodebuildConfiguration.php
@@ -15,7 +15,7 @@ final class XcodebuildConfiguration {
     private $configurationManager;
 
     private $otherFlags;
-    
+
     public function __construct($configuration_manager) {
         $this->configurationManager = $configuration_manager;
     }
@@ -67,7 +67,7 @@ final class XcodebuildConfiguration {
         if ($this->otherFlags) {
             array_push($flags, $this->otherFlags);
         }
-        
+
         $command = new PhutilCommandString(array(
             '%s '
             .'-workspace %s '

--- a/src/configuration/XcodebuildConfiguration.php
+++ b/src/configuration/XcodebuildConfiguration.php
@@ -23,6 +23,7 @@ final class XcodebuildConfiguration {
             .' - xcodebuild.scheme: The workspace scheme to build.'.PHP_EOL
             .' - xcodebuild.configuration: The .xcworkspace to build on. Default: \'Debug\''.PHP_EOL
             .' - xcodebuild.sdk: SDK to build against to. Default: \'iphonesimulator\''.PHP_EOL
+            .' - xcodebuild.other-flags: Other flags for xcodebuild'.PHP_EOL
             .' - bin.xcodebuild: Path to xcodebuild binary. Default \'xcodebuild\'.'.PHP_EOL;
     }
 
@@ -60,6 +61,10 @@ final class XcodebuildConfiguration {
     public function buildCommand(array $flags) {
         $this->loadConfig();
 
+        if ($this->otherFlags) {
+            array_push($flags, $this->otherFlags);
+        }
+        
         $command = new PhutilCommandString(array(
             '%s '
             .'-workspace %s '

--- a/src/configuration/XcodebuildConfiguration.php
+++ b/src/configuration/XcodebuildConfiguration.php
@@ -58,6 +58,7 @@ final class XcodebuildConfiguration {
         $this->configuration = $this->getConfigValue('xcodebuild.configuration', $this->configuration);
         $this->scheme = $this->getConfigValue('xcodebuild.scheme', $this->scheme);
         $this->xcodebuildBin = $this->getXcodebuildPath();
+        $this->otherFlags = $this->getConfigValue('xcodebuild.other-flags');
     }
 
     public function buildCommand(array $flags) {

--- a/src/configuration/XcodebuildConfiguration.php
+++ b/src/configuration/XcodebuildConfiguration.php
@@ -14,6 +14,8 @@ final class XcodebuildConfiguration {
 
     private $configurationManager;
 
+    private $otherFlags;
+    
     public function __construct($configuration_manager) {
         $this->configurationManager = $configuration_manager;
     }

--- a/src/lint/linter/OCLintLinter.php
+++ b/src/lint/linter/OCLintLinter.php
@@ -68,7 +68,7 @@ final class OCLintLinter extends ArcanistCommandLinter {
             touch($path);
         }
 
-        $build_flags = array('-dry-run', 'build');
+        $build_flags = array('build');
         $result = exec_manual('set -o pipefail && '
             .$configuration->buildCommand($build_flags)
             .'| %s '


### PR DESCRIPTION
Removed default param `-dry-run`. Now is optional, can be added into`.arcconfig` file:

```
{
    "project_id" : "MLUI",
    "load": [
        "/usr/local/opt/arc-lint"
    ],
    "xcodebuild.workspace": "MLUI.xcworkspace",
    "xcodebuild.scheme": "MLUIApp",
    "xcodebuild.other-flags": "-dry-run"
}
```

For projects with dynamic frameworks is necessary build the project, but OCLint can't resolve some imports.